### PR TITLE
docs: move contributors badge under package description 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # logger-nodejs
+A simple and fast JSON logging library for Node.js services
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-
-A simple and fast JSON logging library for Node.js services
 
 ## Usage
 


### PR DESCRIPTION
move contributors badge under description so npm search results show up better, ie fixes this:

![Screenshot 2023-08-21 at 11 44 48](https://github.com/cuckoointernet/logger-nodejs/assets/16732873/a4b68192-dd2a-44da-a790-8133a4ea4960)
